### PR TITLE
Mongo ensure index

### DIFF
--- a/source/aura/graph/mongodb/adapter.d
+++ b/source/aura/graph/mongodb/adapter.d
@@ -81,7 +81,11 @@ class GraphMongoAdapter(M ...) : GraphAdapter!(M) {
 	void ensureIndex(M)(int[string] fieldOrders, IndexFlags flags = cast(IndexFlags)0) {
 		getCollection!M.ensureIndex(fieldOrders, flags);
 	}
-	
+
+	void ensureIndex(M)(scope const(Tuple!(string, int))[] fieldOrders, IndexFlags flags = cast(IndexFlags)0) {
+		getCollection!M.ensureIndex(fieldOrders, flags);
+	}
+
 	Bson dropCollection(string collection) {
 		auto command = Bson.emptyObject;
 		command.drop = collection;


### PR DESCRIPTION
An overload of ensureIndex has been added to MongoCollection in vibe.d with which we will be able to specify the order of the keys within each compound index.

Please refer to below of the original issue.
https://github.com/rejectedsoftware/vibe.d/issues/824
